### PR TITLE
Add command center launch and hints

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import "./globals.css"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import CommandCenter from "@/components/command-center"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -26,8 +27,8 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}> 
           {children}
+          <CommandCenter />
       </body>
     </html>
   )
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { Github, Linkedin, Mail, Youtube } from "lucide-react"
 import { TypingAnimation } from "@/components/typing-animation"
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, CarouselApi } from "@/components/ui/carousel"
 import { useEffect, useState } from "react"
+import { COMMAND_CENTER_EVENT } from "@/components/command-center"
 
 export default function Home() {
   const [api, setApi] = useState<CarouselApi>()
@@ -42,7 +43,7 @@ export default function Home() {
   }, [api])
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-4">
+    <div className="max-w-3xl mx-auto px-4 py-4" id="top">
       {/* Header */}
       <header className="flex justify-between items-center mb-6">
         <div className="flex items-center gap-2">
@@ -79,9 +80,19 @@ export default function Home() {
           />
         </div>
       </div>
+      <div className="mb-6 flex flex-wrap items-center justify-center gap-3 text-xs text-gray-600">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new Event(COMMAND_CENTER_EVENT))}
+          className="rounded-full border border-green-200 bg-green-50 px-3 py-1 font-medium text-green-700 transition-all duration-300 hover:border-green-300 hover:bg-green-100"
+        >
+          Command Center
+        </button>
+        <span className="rounded-full border border-gray-200 px-3 py-1">Press ⌘K / Ctrl+K</span>
+      </div>
 
       {/* About Me */}
-      <section className="mb-6">
+      <section className="mb-6" id="about">
         <h2 className="text-xl font-bold mb-2 border-b border-green-500 pb-1 inline-block">About Me</h2>
         <p className="text-sm mb-2">
           Hi, I'm Reda! I enjoy building software with a purpose. I'm not trying to change the world, but solve a couple problems. Coding isn't everything, I love sports (soccer, basketball, running, pickleball, and 100 more), video games (League of Legends, FIFA, Assassin's Creed, and 100 more) and spending time with my family.
@@ -89,7 +100,7 @@ export default function Home() {
       </section>
 
       {/* Achievements Carousel */}
-      <section className="mb-8">
+      <section className="mb-8" id="achievements">
         <Carousel opts={{ loop: true }} setApi={setApi} className="w-full">
           <div 
             style={{ 
@@ -184,7 +195,7 @@ export default function Home() {
       </section>
 
       {/* Work Experience */}
-      <section className="mb-6">
+      <section className="mb-6" id="work">
         <h2 className="text-xl font-bold mb-3 border-b border-green-500 pb-1 inline-block">Work Experience</h2>
 
         <div className="relative border-l-2 border-gray-200 pl-6 ml-4">
@@ -284,7 +295,8 @@ export default function Home() {
 
 
       {/* Latest Publications & Articles */}
-      <section className="mb-6" id="projects">
+      <section className="mb-6" id="publications">
+        <div id="projects" />
         <h2 className="text-xl font-bold mb-3 border-b border-green-500 pb-1 inline-block">Latest Publications & Articles</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <Link href="https://digital.wpi.edu/concern/student_works/v405sf79n?locale=en" className="block">

--- a/components/command-center.tsx
+++ b/components/command-center.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { useEffect, useMemo, useState, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command"
+import {
+  ArrowUpRight,
+  Briefcase,
+  FileText,
+  Github,
+  Home,
+  Info,
+  Linkedin,
+  Mail,
+  Sparkles,
+  Video,
+} from "lucide-react"
+
+const COMMAND_CENTER_EVENT = "command-center:open"
+
+type SectionLink = {
+  id: string
+  label: string
+  icon?: ReactNode
+}
+
+type ExternalLink = {
+  label: string
+  href: string
+  icon?: ReactNode
+}
+
+const PROJECT_LINKS: ExternalLink[] = [
+  {
+    label: "Predicting Ruff Behaviors",
+    href: "https://github.com/RedaB2/accelerometer-analysis-ruffs-behaviors",
+  },
+  {
+    label: "WhyDate?",
+    href: "https://github.com/RedaB2/whydateios",
+  },
+  {
+    label: "Brigham and Women's Hospital",
+    href: "https://github.com/RedaB2/BrighamWomenKiosk",
+  },
+  {
+    label: "PeltonGPT",
+    href: "https://github.com/RedaB2/PeltonGPT",
+  },
+  {
+    label: "Shape of AI",
+    href: "https://redab2.github.io/final/",
+  },
+  {
+    label: "AlphaLasker",
+    href: "https://github.com/RedaB2/AlphaLasker",
+  },
+  {
+    label: "SystemLoggerV1",
+    href: "https://github.com/RedaB2/systemloggerv1",
+  },
+]
+
+export default function CommandCenter() {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  const sectionLinks: SectionLink[] = useMemo(
+    () => [
+      { id: "top", label: "Back to top", icon: <Home /> },
+      { id: "about", label: "About Me", icon: <Info /> },
+      { id: "achievements", label: "Achievements", icon: <Sparkles /> },
+      { id: "latest-video", label: "Latest Video", icon: <Video /> },
+      { id: "work", label: "Work Experience", icon: <Briefcase /> },
+      { id: "publications", label: "Publications", icon: <FileText /> },
+    ],
+    []
+  )
+
+  const externalLinks: ExternalLink[] = useMemo(
+    () => [
+      { label: "GitHub", href: "https://github.com/RedaB2", icon: <Github /> },
+      {
+        label: "LinkedIn",
+        href: "https://www.linkedin.com/in/redabtb/",
+        icon: <Linkedin />,
+      },
+      {
+        label: "YouTube",
+        href: "https://www.youtube.com/watch?v=o26RSEnEgBs",
+        icon: <Video />,
+      },
+    ],
+    []
+  )
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const isTyping =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable
+
+      if (isTyping) {
+        return
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault()
+        setOpen((prev) => !prev)
+      }
+    }
+
+    const handleOpenEvent = () => setOpen(true)
+
+    window.addEventListener("keydown", handleKeyDown)
+    window.addEventListener(COMMAND_CENTER_EVENT, handleOpenEvent)
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener(COMMAND_CENTER_EVENT, handleOpenEvent)
+    }
+  }, [])
+
+  const openUrl = (href: string) => {
+    window.open(href, "_blank", "noopener,noreferrer")
+  }
+
+  const goToSection = (id: string) => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    if (window.location.pathname !== "/") {
+      const target = id === "top" ? "/" : `/#${id}`
+      window.location.assign(target)
+      return
+    }
+
+    if (id === "top") {
+      window.scrollTo({ top: 0, behavior: "smooth" })
+      return
+    }
+
+    const element = document.getElementById(id)
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" })
+      window.history.replaceState(null, "", `#${id}`)
+    }
+  }
+
+  const handleSelect = (callback: () => void) => {
+    callback()
+    setOpen(false)
+  }
+
+  const handleRandomProject = () => {
+    const random = PROJECT_LINKS[Math.floor(Math.random() * PROJECT_LINKS.length)]
+    openUrl(random.href)
+  }
+
+  const handleCopyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText("boutayeb.reda@icloud.com")
+    } catch (error) {
+      console.error("Failed to copy email", error)
+    }
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Search commands..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Navigate">
+          {sectionLinks.map((section) => (
+            <CommandItem
+              key={section.id}
+              onSelect={() => handleSelect(() => goToSection(section.id))}
+            >
+              {section.icon}
+              <span>{section.label}</span>
+            </CommandItem>
+          ))}
+          <CommandItem onSelect={() => handleSelect(() => router.push("/projects"))}>
+            <ArrowUpRight />
+            <span>Projects page</span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="External">
+          {externalLinks.map((link) => (
+            <CommandItem
+              key={link.href}
+              onSelect={() => handleSelect(() => openUrl(link.href))}
+            >
+              {link.icon}
+              <span>{link.label}</span>
+              <CommandShortcut>Open</CommandShortcut>
+            </CommandItem>
+          ))}
+          <CommandItem
+            onSelect={() => handleSelect(() => openUrl("mailto:boutayeb.reda@icloud.com"))}
+          >
+            <Mail />
+            <span>Email me</span>
+          </CommandItem>
+          <CommandItem onSelect={() => handleSelect(handleCopyEmail)}>
+            <Mail />
+            <span>Copy email</span>
+            <CommandShortcut>Copy</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Surprise">
+          <CommandItem onSelect={() => handleSelect(handleRandomProject)}>
+            <Sparkles />
+            <span>Open a random project</span>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}
+
+export { COMMAND_CENTER_EVENT }

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -6,7 +6,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -27,6 +27,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command Center</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
Summary
- add a command center dialog that can be invoked via keyboard shortcut, button, or event and reuse it across the app layout for global access (`components/command-center.tsx`)
- surface a visual hint on the landing page and wire the command dialog into the home sections so visitors can jump around (`app/page.tsx`)
- ensure the command primitive dialog meets Radix accessibility expectations by providing a hidden title (`components/ui/command.tsx`)

Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a client-side command palette and in-page anchors; main risk is minor UX/accessibility regressions or shortcut conflicts.
> 
> **Overview**
> Adds a global **Command Center** command-palette dialog (mounted in `app/layout.tsx`) that can be opened via ⌘K/Ctrl+K or a custom `command-center:open` window event, and provides quick actions to scroll to home-page sections, open external links, copy email, and open a random project.
> 
> Updates the home page to expose a *Command Center* button + keyboard hint and adds section `id`s/anchors (`top`, `about`, `achievements`, `work`, `publications`, etc.) so the palette can jump visitors around the page.
> 
> Improves accessibility of the underlying `CommandDialog` by adding a hidden `DialogTitle` in `components/ui/command.tsx` to satisfy Radix dialog expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f68761040762325cf85909f1b653bd6580685d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->