### PR TITLE
Refresh home and projects content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 
 # testing
 /coverage
+/.playwright-cli/
+/output/playwright/
 
 # next.js
 /.next/

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,13 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { Github, Linkedin, Mail, Youtube } from "lucide-react"
+import { Youtube } from "lucide-react"
 import { TypingAnimation } from "@/components/typing-animation"
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, CarouselApi } from "@/components/ui/carousel"
 import { useEffect, useState } from "react"
 import { COMMAND_CENTER_EVENT } from "@/components/command-center"
-import { LAST_UPDATED } from "@/lib/site"
 import MusicPreviewRail from "@/components/music-preview-rail"
+import SiteFooter from "@/components/site-footer"
 
 export default function Home() {
   const [api, setApi] = useState<CarouselApi>()
@@ -203,6 +203,27 @@ export default function Home() {
         <h2 className="text-xl font-bold mb-3 border-b border-green-500 pb-1 inline-block">Work Experience</h2>
 
         <div className="relative border-l-2 border-gray-200 pl-6 ml-4">
+          {/* Adobe */}
+          <div className="mb-6 relative">
+            <div className="absolute -left-10 w-8 h-8 rounded-full bg-white flex items-center justify-center overflow-hidden border-2 border-gray-200">
+              <Image
+                src="/adobe-logo.svg"
+                alt="Adobe Logo"
+                width={40}
+                height={40}
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <div className="bg-red-50 text-red-950 p-4 rounded-lg border border-red-100 transition-all duration-300 hover:shadow-xl hover:-translate-y-1">
+              <h3 className="text-lg font-bold">Adobe</h3>
+              <p className="text-red-700 text-sm">Software Engineering Intern 🧑‍💻</p>
+              <p className="mt-2 text-sm">
+                Incoming on the DX Team for A2A, customer workflow and experience improvement.
+              </p>
+              <p className="mt-2 text-xs">Summer 2026</p>
+            </div>
+          </div>
+
           {/* Capgemini Engineering */}
           <div className="mb-6 relative">
             <div className="absolute -left-10 w-8 h-8 rounded-full bg-white flex items-center justify-center overflow-hidden border-2 border-gray-200">
@@ -221,7 +242,7 @@ export default function Home() {
                 Building AI Agents and full stack applications for Healthcare companies. Streamlining healthcare operations. Also, on the side, diving
                 into GPU programming with CUDA!! 🏥⚡
               </p>
-              <p className="mt-2 text-xs">June 2025</p>
+              <p className="mt-2 text-xs">June 2025 - April 2026</p>
             </div>
           </div>
 
@@ -243,7 +264,7 @@ export default function Home() {
                 I'm overseeing all backend services of the CollegeROI platform. Recently, I helped by building a new search engine that helps go through colleges with specific criteries (distance, cost, size, and more). Very fun work and it's helping students out there making one of the most important decision of their lives: college. ✌️ <br></br>
                 <a href="https://www.yourcollegeroi.com/" className="text-blue-500 hover:underline">https://www.yourcollegeroi.com/</a>
               </p>
-              <p className="mt-2 text-xs">February 2025</p>
+              <p className="mt-2 text-xs">February 2025 - June 2025</p>
             </div>
           </div>
 
@@ -354,30 +375,7 @@ export default function Home() {
         </div>
       </section>
 
-      <footer className="flex justify-center gap-4 pt-4 border-t border-gray-200">
-        <Link
-          href="https://github.com/RedaB2"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Github size={20} />
-          <span className="sr-only">GitHub</span>
-        </Link>
-        <Link
-          href="https://www.linkedin.com/in/redabtb/"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Linkedin size={20} />
-          <span className="sr-only">LinkedIn</span>
-        </Link>
-        <Link
-          href="mailto:boutayeb.reda@icloud.com"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Mail size={20} />
-          <span className="sr-only">Email</span>
-        </Link>
-      </footer>
-        <p className="text-center text-gray-400 text-sm mt-2">Last updated: {LAST_UPDATED}</p>
+      <SiteFooter />
       </div>
     </>
   )

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,11 +1,63 @@
 import Link from "next/link"
 import Image from "next/image"
-import { Github, Linkedin, Mail } from "lucide-react"
-import { LAST_UPDATED } from "@/lib/site"
+import { PROJECTS, type Project } from "@/lib/projects"
 import HoverVideo from "../components/hover-video"
 import ShapeOfAIVideo from "../components/shape-of-ai-video"
 import PeltonGPTVideo from "../components/pelton-gpt-video"
 import MusicPreviewRail from "@/components/music-preview-rail"
+import SiteFooter from "@/components/site-footer"
+
+function ProjectMedia({ project }: { project: Project }) {
+  const { media } = project
+
+  if (media.type === "video") {
+    if (media.video === "pelton-gpt") {
+      return <PeltonGPTVideo />
+    }
+
+    if (media.video === "shape-of-ai") {
+      return <ShapeOfAIVideo />
+    }
+
+    return <HoverVideo />
+  }
+
+  const imageFitClass = media.fit === "contain" ? "object-contain" : "object-cover"
+  const image = (
+    <Image
+      src={media.src}
+      alt={media.alt}
+      width={400}
+      height={200}
+      className={`w-full h-48 ${imageFitClass}`}
+    />
+  )
+
+  if (media.framed) {
+    return <div className="w-full h-48 bg-gray-100 flex items-center justify-center">{image}</div>
+  }
+
+  return image
+}
+
+function ProjectCard({ project }: { project: Project }) {
+  return (
+    <Link href={project.href}>
+      <div className="flex flex-col items-center">
+        <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
+          <ProjectMedia project={project} />
+        </div>
+        <h2 className="text-xl font-bold mt-3 mb-1">{project.title}</h2>
+        <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
+          {project.description}
+        </p>
+        {project.detail ? (
+          <p className="text-xs text-gray-500">{project.detail}</p>
+        ) : null}
+      </div>
+    </Link>
+  )
+}
 
 export default function Projects() {
   return (
@@ -36,171 +88,11 @@ export default function Projects() {
       </div>
     {/* Projects Grid */}
     <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-10 mb-8">
-        {/* Project 1 */}
-        <Link href="https://github.com/RedaB2/mandarin">
-          <div className="flex flex-col items-center">
-            <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-              <div className="w-full h-48 bg-gray-100 flex items-center justify-center">
-                <Image
-                  src="/mandarin-logo.png?height=200&width=400"
-                  alt="Mandarin logo"
-                  width={400}
-                  height={200}
-                  className="w-full h-48 object-contain"
-                />
-              </div>
-            </div>
-            <h2 className="text-xl font-bold mt-3 mb-1">Mandarin</h2>
-            <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-              Context management tool for LLM discussion and chatting, built through open-source contributions.
-            </p>
-            <p className="text-xs text-gray-500">Keeps long AI conversations organized</p>
-          </div>
-        </Link>
-
-        {/* Project 2 */}
-        <Link href="https://github.com/RedaB2/accelerometer-analysis-ruffs-behaviors">
-          <div className="flex flex-col items-center">
-            <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-              <Image
-                src="/poster_presentation.jpeg?height=200&width=400"
-                alt="Ruff Behaviors Analysis"
-                width={400}
-                height={200}
-                className="w-full h-48 object-cover"
-              />
-            </div>
-            <h2 className="text-xl font-bold mt-3 mb-1">Predicting Ruff Behaviors 🦃</h2>
-            <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-              Deep Learning class survived & our project outperformed published research 🤗
-            </p>
-          </div>
-        </Link>
-
-        {/* Project 3 */}
-        <Link href="https://github.com/RedaB2/whydateios">
-          <div className="flex flex-col items-center">
-            <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-              <Image
-                src="/whydate.png?height=200&width=400"
-                alt="whydatepj1"
-                width={400}
-                height={200}
-                className="w-full h-48 object-cover"
-              />
-            </div>
-            <h2 className="text-xl font-bold mt-3 mb-1">WhyDate?</h2>
-            <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-              Fun & original iOS dating app created for students at WPI.
-            </p>
-            <p className="text-xs text-gray-500">40+ Testflight downloads (mostly friends & family 💀)</p>
-          </div>
-        </Link>
-
-        {/* Project 4 */}
-        <Link href="https://github.com/RedaB2/BrighamWomenKiosk">
-        <div className="flex flex-col items-center">
-          <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-            <Image
-              src="/kioskdemo.png?height=200&width=400"
-              alt="Kiosk Demo"
-              width={400}
-              height={200}
-              className="w-full h-48 object-cover"
-            />
-          </div>
-          <h2 className="text-xl font-bold mt-3 mb-1">Brigham and Women's Hospital</h2>
-          <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-            Web app to be used by patients & staff at Brigham and Women's Hospital. Packed with cool features like pathfinding in the hospital and flower ordering.
-          </p>
-          <p className="text-xs text-gray-500">2nd Place @ CS3733</p>
-        </div>
-        </Link>
-        {/* Project 5 */}
-        <Link href="https://github.com/RedaB2/PeltonGPT">
-        <div className="flex flex-col items-center">
-          <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-            <PeltonGPTVideo />
-          </div>
-          <h2 className="text-xl font-bold mt-3 mb-1">PeltonGPT</h2>
-          <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-            LLM powered research assistant for Professor Ono's research lab on fluid dynamics at Shibaura Institute of Technology.
-          </p>
-          <p className="text-xs text-gray-500">Improved research efficiency by 45%</p>
-        </div>
-        </Link>
-        {/* Project 6 */}
-        <Link href="https://redab2.github.io/final/">
-        <div className="flex flex-col items-center">
-          <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-            <ShapeOfAIVideo />
-          </div>
-          <h2 className="text-xl font-bold mt-3 mb-1">Shape of AI</h2>
-          <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-            Web app to help visualize AI models with human knowledge. Inspired by Yann LeCun's talk at the Summit 2025.
-          </p>
-          <p className="text-xs text-gray-500">Is a 4 year old child smarter than ChatGPT?</p>
-        </div>
-        </Link>
-        {/* Project 7 */}
-        <Link href="https://github.com/RedaB2/AlphaLasker">
-          <div className="flex flex-col items-center">
-            <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-              <HoverVideo />
-            </div>
-            <h2 className="text-xl font-bold mt-3 mb-1">AlphaLasker</h2>
-            <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-              A Lasker Morris player powered by Gemini API. Smart decision making, fast response time and fallback on hardcoded algorithm if API fails.
-            </p>
-            <p className="text-xs text-gray-500">Can you beat it at Lasker Morris?</p>
-          </div>
-        </Link>
-        {/* Project 8 */}
-        <Link href="https://github.com/RedaB2/systemloggerv1">
-          <div className="flex flex-col items-center">
-            <div className="overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 w-full">
-              <div className="w-full h-48 bg-gray-100 flex items-center justify-center">
-              <Image
-              src="/systemloggerv1.png?height=200&width=400"
-              alt="Kiosk Demo"
-              width={100}
-              height={50}
-              className="w-full h-48 object-contain"
-            />
-              </div>
-            </div>
-            <h2 className="text-xl font-bold mt-3 mb-1">SystemLoggerV1</h2>
-            <p className="text-sm text-gray-600 text-center mb-1 max-w-xs">
-              Lightweight C++ system logger for embedded Linux devices 💡
-            </p>
-            <p className="text-xs text-gray-500">Great way to learn C++ and Linux</p>
-          </div>
-        </Link>
+        {PROJECTS.map((project) => (
+          <ProjectCard key={project.href} project={project} />
+        ))}
       </div>
-      <footer className="flex justify-center gap-4 pt-4 border-t border-gray-200">
-        <Link
-          href="https://github.com/RedaB2"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Github size={20} />
-          <span className="sr-only">GitHub</span>
-        </Link>
-        <Link
-          href="https://www.linkedin.com/in/redabtb/"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Linkedin size={20} />
-          <span className="sr-only">LinkedIn</span>
-        </Link>
-        <Link
-          href="mailto:boutayeb.reda@icloud.com"
-          className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
-        >
-          <Mail size={20} />
-          <span className="sr-only">Email</span>
-        </Link>
-      </footer>
-        <p className="text-center text-gray-400 text-sm mt-2">Last updated: {LAST_UPDATED}</p>
+      <SiteFooter />
       </div>
     </>
   )

--- a/components/command-center.tsx
+++ b/components/command-center.tsx
@@ -24,6 +24,7 @@ import {
   Sparkles,
   Video,
 } from "lucide-react"
+import { PROJECTS } from "@/lib/projects"
 
 const COMMAND_CENTER_EVENT = "command-center:open"
 
@@ -39,36 +40,10 @@ type ExternalLink = {
   icon?: ReactNode
 }
 
-const PROJECT_LINKS: ExternalLink[] = [
-  {
-    label: "Predicting Ruff Behaviors",
-    href: "https://github.com/RedaB2/accelerometer-analysis-ruffs-behaviors",
-  },
-  {
-    label: "WhyDate?",
-    href: "https://github.com/RedaB2/whydateios",
-  },
-  {
-    label: "Brigham and Women's Hospital",
-    href: "https://github.com/RedaB2/BrighamWomenKiosk",
-  },
-  {
-    label: "PeltonGPT",
-    href: "https://github.com/RedaB2/PeltonGPT",
-  },
-  {
-    label: "Shape of AI",
-    href: "https://redab2.github.io/final/",
-  },
-  {
-    label: "AlphaLasker",
-    href: "https://github.com/RedaB2/AlphaLasker",
-  },
-  {
-    label: "SystemLoggerV1",
-    href: "https://github.com/RedaB2/systemloggerv1",
-  },
-]
+const PROJECT_LINKS: ExternalLink[] = PROJECTS.map((project) => ({
+  label: project.title,
+  href: project.href,
+}))
 
 export default function CommandCenter() {
   const router = useRouter()

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link"
+import { Github, Linkedin, Mail } from "lucide-react"
+import { LAST_UPDATED } from "@/lib/site"
+
+const FOOTER_LINKS = [
+  {
+    href: "https://github.com/RedaB2",
+    label: "GitHub",
+    icon: Github,
+  },
+  {
+    href: "https://www.linkedin.com/in/redabtb/",
+    label: "LinkedIn",
+    icon: Linkedin,
+  },
+  {
+    href: "mailto:boutayeb.reda@icloud.com",
+    label: "Email",
+    icon: Mail,
+  },
+]
+
+export default function SiteFooter() {
+  return (
+    <>
+      <footer className="flex justify-center gap-4 pt-4 border-t border-gray-200">
+        {FOOTER_LINKS.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="text-gray-600 hover:text-gray-900 transition-all duration-300 hover:scale-110"
+          >
+            <Icon size={20} />
+            <span className="sr-only">{label}</span>
+          </Link>
+        ))}
+      </footer>
+      <p className="text-center text-gray-400 text-sm mt-2">
+        Last updated: {LAST_UPDATED}
+      </p>
+    </>
+  )
+}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -54,8 +54,18 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        Chevron: ({ orientation, className }) => {
+          const Icon =
+            orientation === "left"
+              ? ChevronLeft
+              : orientation === "right"
+                ? ChevronRight
+                : orientation === "up"
+                  ? ChevronUp
+                  : ChevronDown
+
+          return <Icon className={cn("h-4 w-4", className)} />
+        },
       }}
       {...props}
     />

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,117 @@
+export type ProjectMedia =
+  | {
+      type: "image"
+      src: string
+      alt: string
+      fit?: "cover" | "contain"
+      framed?: boolean
+    }
+  | {
+      type: "video"
+      video: "pelton-gpt" | "shape-of-ai" | "alpha-lasker"
+    }
+
+export type Project = {
+  title: string
+  href: string
+  description: string
+  detail?: string
+  media: ProjectMedia
+}
+
+export const PROJECTS: Project[] = [
+  {
+    title: "Mandarin",
+    href: "https://github.com/RedaB2/mandarin",
+    description:
+      "Context management tool for LLM discussion and chatting, built through open-source contributions.",
+    detail: "Keeps long AI conversations organized",
+    media: {
+      type: "image",
+      src: "/mandarin-logo.png?height=200&width=400",
+      alt: "Mandarin logo",
+      fit: "contain",
+      framed: true,
+    },
+  },
+  {
+    title: "Predicting Ruff Behaviors 🦃",
+    href: "https://github.com/RedaB2/accelerometer-analysis-ruffs-behaviors",
+    description:
+      "Deep Learning class survived & our project outperformed published research 🤗",
+    media: {
+      type: "image",
+      src: "/poster_presentation.jpeg?height=200&width=400",
+      alt: "Ruff Behaviors Analysis",
+    },
+  },
+  {
+    title: "WhyDate?",
+    href: "https://github.com/RedaB2/whydateios",
+    description: "Fun & original iOS dating app created for students at WPI.",
+    detail: "40+ Testflight downloads (mostly friends & family 💀)",
+    media: {
+      type: "image",
+      src: "/whydate.png?height=200&width=400",
+      alt: "WhyDate app screenshot",
+    },
+  },
+  {
+    title: "Brigham and Women's Hospital",
+    href: "https://github.com/RedaB2/BrighamWomenKiosk",
+    description:
+      "Web app to be used by patients & staff at Brigham and Women's Hospital. Packed with cool features like pathfinding in the hospital and flower ordering.",
+    detail: "2nd Place @ CS3733",
+    media: {
+      type: "image",
+      src: "/kioskdemo.png?height=200&width=400",
+      alt: "Kiosk demo",
+    },
+  },
+  {
+    title: "PeltonGPT",
+    href: "https://github.com/RedaB2/PeltonGPT",
+    description:
+      "LLM powered research assistant for Professor Ono's research lab on fluid dynamics at Shibaura Institute of Technology.",
+    detail: "Improved research efficiency by 45%",
+    media: {
+      type: "video",
+      video: "pelton-gpt",
+    },
+  },
+  {
+    title: "Shape of AI",
+    href: "https://redab2.github.io/final/",
+    description:
+      "Web app to help visualize AI models with human knowledge. Inspired by Yann LeCun's talk at the Summit 2025.",
+    detail: "Is a 4 year old child smarter than ChatGPT?",
+    media: {
+      type: "video",
+      video: "shape-of-ai",
+    },
+  },
+  {
+    title: "AlphaLasker",
+    href: "https://github.com/RedaB2/AlphaLasker",
+    description:
+      "A Lasker Morris player powered by Gemini API. Smart decision making, fast response time and fallback on hardcoded algorithm if API fails.",
+    detail: "Can you beat it at Lasker Morris?",
+    media: {
+      type: "video",
+      video: "alpha-lasker",
+    },
+  },
+  {
+    title: "SystemLoggerV1",
+    href: "https://github.com/RedaB2/systemloggerv1",
+    description: "Lightweight C++ system logger for embedded Linux devices 💡",
+    detail: "Great way to learn C++ and Linux",
+    media: {
+      type: "image",
+      src: "/systemloggerv1.png?height=200&width=400",
+      alt: "SystemLoggerV1 screenshot",
+      fit: "contain",
+      framed: true,
+    },
+  },
+]

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,1 +1,1 @@
-export const LAST_UPDATED = "March 1, 2026"
+export const LAST_UPDATED = "April 23, 2026"

--- a/public/adobe-logo.svg
+++ b/public/adobe-logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Adobe logo">
+  <rect width="512" height="512" fill="#f40000"/>
+  <g fill="#ffffff">
+    <path d="M147 126h91L147 351z"/>
+    <path d="M365 126h-91l91 225z"/>
+    <path d="M256 202l61 149h-48l-16-43h-42z"/>
+    <text
+      x="256"
+      y="424"
+      text-anchor="middle"
+      font-family="Arial, Helvetica, sans-serif"
+      font-size="74"
+      font-weight="700"
+      letter-spacing="2"
+    >
+      Adobe
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add the Adobe internship and refreshed work history details to the home page
- centralize project metadata so the projects page and command center stay in sync
- extract a shared site footer and update related site assets and metadata

## Test plan
- [x] `npm run build`
- [ ] `npm run lint` (prompts for initial Next.js ESLint setup in this repo)


Made with [Cursor](https://cursor.com)